### PR TITLE
Add context functions

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,0 +1,28 @@
+package opentracefasthttp
+
+import (
+	"github.com/opentracing/opentracing-go"
+	"github.com/valyala/fasthttp"
+)
+
+const contextKey = "github.com/wawan93/opentracefasthttp span"
+
+// ContextWithSpan returns a new `*fasthttp.RequestCtx` that holds a reference to
+// the span. If span is nil, a new context without an active span is returned.
+func ContextWithSpan(ctx *fasthttp.RequestCtx, span opentracing.Span) *fasthttp.RequestCtx {
+	if ctx == nil {
+		return nil
+	}
+	ctx.SetUserValue(contextKey, span)
+	return ctx
+}
+
+// SpanFromContext returns the `opentracing.Span` previously associated with `ctx`, or
+// `nil` if no such `opentracing.Span` could be found.
+func SpanFromContext(ctx *fasthttp.RequestCtx) opentracing.Span {
+	v := ctx.UserValue(contextKey)
+	if span, ok := v.(opentracing.Span); ok {
+		return span
+	}
+	return nil
+}


### PR DESCRIPTION
set span to `*fasthttp.RequestCtx` inside a middleware:
```go
func TracingMiddleware(ctx *fasthttp.RequestCtx) error {
	...

	carrier := opentracefasthttp.New(&ctx.Request.Header)
	spanCtx, _ := tr.Extract(opentracing.HTTPHeaders, carrier)

	span := tr.StartSpan(string(ctx.Request.URI().Path()), opentracing.ChildOf(spanCtx))
	defer span.Finish()
	...

	// returns *fasthttp.RequestCtx
	ctx = opentracefasthttp.ContextWithSpan(ctx, span)
	...

	// so, we can do this
	return ctx.Next()
}
```

extract span from `*fasthttp.RequestCtx`:
```go
func Handler(ctx *fasthttp.RequestCtx) error {
	...
	if rc, ok := ctx.(*fasthttp.RequestCtx); ok {
		span = opentracefasthttp.SpanFromContext(rc)
	} else {
		span = opentracing.SpanFromContext(ctx)
	}
	...
}
```